### PR TITLE
Refactor API types and dynamic goals

### DIFF
--- a/api/mock-data.ts
+++ b/api/mock-data.ts
@@ -1,5 +1,13 @@
 // Mock data derived from the provided real data
-import type { UserActivity, UserAverage, UserMainData, UserPerformance, UserData } from './my-types'
+import type {
+  UserActivity,
+  UserAverage,
+  UserMainData,
+  UserPerformance,
+  UserData,
+  UserGoal,
+  Goal,
+} from './types.ts'
 
 export const USER_MAIN_DATA: UserMainData[] = [
   {
@@ -141,6 +149,75 @@ export const USER_PERFORMANCE: UserPerformance[] = [
   },
 ]
 
+export const USER_GOALS: UserGoal[] = [
+  {
+    userId: 12,
+    goals: [
+      {
+        type: 'workout',
+        objectif: { value: '1', unit: 'h' },
+        title: 'Squat',
+        details: '8x15 rep, 30s',
+        done: false,
+      },
+      {
+        type: 'cycling',
+        objectif: { value: '10', unit: 'km' },
+        title: "Parc de l'étoile",
+        details: 'Parcoure extérieur',
+        done: true,
+      },
+      {
+        type: 'swimming',
+        objectif: { value: '30', unit: 'min' },
+        title: 'Piscine municipale',
+        details: 'Nager crawl et brasse',
+        done: false,
+      },
+      {
+        type: 'yoga',
+        objectif: { value: '45', unit: 'min' },
+        title: 'Vinyasa Flow',
+        details: 'Étirements et respiration',
+        done: false,
+      },
+    ],
+  },
+  {
+    userId: 18,
+    goals: [
+      {
+        type: 'workout',
+        objectif: { value: '1', unit: 'h' },
+        title: 'Squat',
+        details: '8x15 rep, 30s',
+        done: false,
+      },
+      {
+        type: 'cycling',
+        objectif: { value: '10', unit: 'km' },
+        title: "Parc de l'étoile",
+        details: 'Parcoure extérieur',
+        done: true,
+      },
+      {
+        type: 'swimming',
+        objectif: { value: '30', unit: 'min' },
+        title: 'Piscine municipale',
+        details: 'Nager crawl et brasse',
+        done: false,
+      },
+      {
+        type: 'yoga',
+        objectif: { value: '45', unit: 'min' },
+        title: 'Vinyasa Flow',
+        details: 'Étirements et respiration',
+        done: false,
+      },
+    ],
+  },
+]
+
 export const USERS_DATA: UserData[] = USER_MAIN_DATA.map((user) => ({
   id: user.id,
   firstName: user.userInfos.firstName,
@@ -161,6 +238,7 @@ export const USERS_DATA: UserData[] = USER_MAIN_DATA.map((user) => ({
     kind: {},
     data: [],
   },
+  goals: USER_GOALS.find((g) => g.userId === user.id)?.goals ?? [],
 }))
 
 export default USERS_DATA

--- a/api/mock-data.ts
+++ b/api/mock-data.ts
@@ -6,7 +6,6 @@ import type {
   UserPerformance,
   UserData,
   UserGoal,
-  Goal,
 } from './types.ts'
 
 export const USER_MAIN_DATA: UserMainData[] = [
@@ -179,7 +178,7 @@ export const USER_GOALS: UserGoal[] = [
         objectif: { value: '45', unit: 'min' },
         title: 'Vinyasa Flow',
         details: 'Étirements et respiration',
-        done: false,
+        done: true,
       },
     ],
   },

--- a/api/types.ts
+++ b/api/types.ts
@@ -61,6 +61,24 @@ export interface UserPerformance {
   data: PerformanceEntry[]
 }
 
+export interface GoalObjectif {
+  value: string
+  unit: string
+}
+
+export interface Goal {
+  type: 'workout' | 'cycling' | 'swimming' | 'yoga'
+  objectif: GoalObjectif
+  title: string
+  details: string
+  done: boolean
+}
+
+export interface UserGoal {
+  userId: number
+  goals: Goal[]
+}
+
 export interface UserData {
   id: number
   firstName: string
@@ -81,4 +99,5 @@ export interface UserData {
     kind: PerformanceKind
     data: PerformanceEntry[]
   }
+  goals: Goal[]
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import Dashboard from '@/components/Dashboard/Dashboard.tsx'
 import Footer from '@/components/Footer.tsx'
 import { useQuery } from '@tanstack/react-query'
 import { fetchUserData } from '@/hooks/user.tsx'
-import type { UserData } from '../api/my-types'
+import type { UserData } from '../api/types'
 
 const Layout = styled.main`
   width: 100%;

--- a/src/components/DailyGoal.tsx
+++ b/src/components/DailyGoal.tsx
@@ -5,48 +5,11 @@ import YogaIcon from '@/assets/icons/yoga.svg?react'
 import SwimmingIcon from '@/assets/icons/swimming.svg?react'
 import CyclingIcon from '@/assets/icons/cycling.svg?react'
 import WorkoutIcon from '@/assets/icons/workout.svg?react'
+import type { Goal } from '../../api/types'
 
-interface Goal {
-  type: 'workout' | 'cycling' | 'swimming' | 'yoga'
-  objectif: {
-    value: string
-    unit: string
-  }
-  title: string
-  details: string
-  done: boolean
+interface DailyGoalProps {
+  goals: Goal[]
 }
-
-const initialGoals: Goal[] = [
-  {
-    type: 'workout',
-    objectif: { value: '1', unit: 'h' },
-    title: 'Squat',
-    details: '8x15 rep, 30s',
-    done: false,
-  },
-  {
-    type: 'cycling',
-    objectif: { value: '10', unit: 'km' },
-    title: "Parc de l'étoile",
-    details: 'Parcoure extérieur',
-    done: true,
-  },
-  {
-    type: 'swimming',
-    objectif: { value: '30', unit: 'min' },
-    title: 'Piscine municipale',
-    details: 'Nager crawl et brasse',
-    done: false,
-  },
-  {
-    type: 'yoga',
-    objectif: { value: '45', unit: 'min' },
-    title: 'Vinyasa Flow',
-    details: 'Étirements et respiration',
-    done: false,
-  },
-]
 
 const goalTheme = {
   workout: {
@@ -271,8 +234,8 @@ const GoalProgress = styled.div<{ $completed: boolean }>`
   gap: 4px;
 `
 
-const DailyGoal = () => {
-  const [userGoals, setUserGoals] = useState(initialGoals)
+const DailyGoal = ({ goals }: DailyGoalProps) => {
+  const [userGoals, setUserGoals] = useState(goals)
 
   const handleToggle = (idx: number) => {
     setUserGoals((goals) => goals.map((g, i) => (i === idx ? { ...g, done: !g.done } : g)))
@@ -285,7 +248,7 @@ const DailyGoal = () => {
     }
   }
 
-  const getCompletedGoalsCount = (goals: typeof userGoals) =>
+  const getCompletedGoalsCount = (goals: Goal[]) =>
     goals.filter((goal) => goal.done).length
 
   const completedGoals = getCompletedGoalsCount(userGoals)

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import ProfileCard from '@/components/ProfileCard.tsx'
 import MacroCard from '@/components/MacroCard.tsx'
 import DailyGoal from '@/components/DailyGoal.tsx'
-import type { UserData } from '../../../api/my-types'
+import type { UserData } from '../../../api/types'
 
 const DashboardContainer = styled.section`
   display: flex;
@@ -48,7 +48,7 @@ const Dashboard = ({ user }: DashboardProps) => {
         <div>
           <ProfileCard user={user} onEdit={() => console.log('Edit clicked')} />
           <MacroCard />
-          <DailyGoal />
+          <DailyGoal goals={user.goals} />
         </div>
       </div>
     </DashboardContainer>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 import { Pencil2Icon } from '@radix-ui/react-icons'
-import type { UserData } from '../../api/my-types'
+import type { UserData } from '../../api/types'
 
 export interface UserProfile {
   user: UserData

--- a/src/hooks/user.tsx
+++ b/src/hooks/user.tsx
@@ -1,4 +1,4 @@
-import type { UserData } from '../../api/my-types'
+import type { UserData } from '../../api/types'
 
 export const fetchUserData = async (): Promise<UserData> => {
   const res = await fetch('/api/users/12')


### PR DESCRIPTION
## Summary
- refactor API type declarations into `types.ts`
- include goal-related interfaces
- add `USER_GOALS` data and expose goals in `USERS_DATA`
- adapt frontend imports to new types file
- load daily goals from user data via props

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685da427dfc48332b218610d4e02f17c