### PR TITLE
Accessibility and cleanup

### DIFF
--- a/api/users.ts
+++ b/api/users.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import USERS_DATA from './mock-data.ts'
 
-export default function handler(_req: VercelRequest, res: VercelResponse) {
+export default function handler(_req: VercelRequest, res: VercelResponse): void {
   res.status(200).json(USERS_DATA)
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,10 +1,10 @@
 #root {
-    display: flex;
-    width: 100%;
-    height: 100%;
-    flex-direction: column;
-    justify-content: flex-start;
-    align-items: flex-start;
-    margin: 0 auto;
-    text-align: center
+  display: flex;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  margin: 0 auto;
+  text-align: center;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ const Layout = styled.main`
   width: 100%;
   height: 100%;
   display: flex;
-  padding: 30px 40px;
+  padding: 2rem 2.5rem;
   align-items: flex-start;
   gap: 40px;
 `

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,9 +13,9 @@ const Layout = styled.main`
   width: 100%;
   height: 100%;
   display: flex;
-  padding: 2rem 2.5rem;
+  padding: 32px 40px;
   align-items: flex-start;
-  gap: 40px;
+  gap: 2.5rem;
 `
 
 const App = () => {

--- a/src/components/DailyGoal.tsx
+++ b/src/components/DailyGoal.tsx
@@ -40,14 +40,14 @@ const goalTheme = {
 
 const Card = styled.section`
   display: flex;
-  padding: 2rem 1.5rem;
+  padding: 32px 24px;
   flex-direction: column;
   align-items: flex-start;
-  gap: 24px;
+  gap: 1.5rem;
   align-self: stretch;
   background: #fff;
-  border-radius: 1rem;
-  box-shadow: 0 0.125rem 0.75rem rgba(32, 32, 56, 0.06);
+  border-radius: 16px;
+  box-shadow: 0 2px 12px rgba(32, 32, 56, 0.06);
 `
 
 const CardHeader = styled.header`
@@ -58,21 +58,21 @@ const CardHeader = styled.header`
 
   > div {
     display: flex;
-    gap: 8px;
+    gap: 0.5rem;
   }
 
   h3 {
     color: #1e1f24;
 
-    font-size: 16px;
+    font-size: 1rem;
     font-style: normal;
     font-weight: 500;
     line-height: normal;
   }
 
   svg {
-    width: 1.5rem;
-    height: 1.5rem;
+    width: 24px;
+    height: 24px;
     color: #c1c1c1;
     cursor: pointer;
 
@@ -88,30 +88,30 @@ const GoalList = styled.ul`
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 1rem;
   align-self: stretch;
 `
 
 const GoalItem = styled.li`
   display: flex;
-  gap: 16px;
+  gap: 1rem;
   align-items: flex-start;
 `
 
 const GoalIconBox = styled.div<{ $main: string }>`
-  width: 2.5rem;
-  height: 2.5rem;
-  min-width: 2.5rem;
-  min-height: 2.5rem;
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
+  min-height: 40px;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 0.75rem;
+  border-radius: 12px;
   background: ${({ $main }) => $main};
 
   svg {
-    width: 1.5rem;
-    height: 1.5rem;
+    width: 24px;
+    height: 24px;
     display: block;
     fill: #fff;
     color: #fff;
@@ -127,7 +127,7 @@ const GoalInfo = styled.article`
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 0.5rem;
   align-items: flex-start;
 `
 
@@ -135,13 +135,13 @@ const GoalHeader = styled.div`
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 15px;
+  font-size: 0.9375rem;
   color: #232326;
   font-weight: 600;
 `
 
 const GoalObjectif = styled.span`
-  font-size: 15px;
+  font-size: 0.9375rem;
   color: #62636c;
   font-weight: 500;
 `
@@ -149,17 +149,17 @@ const GoalObjectif = styled.span`
 const GoalDetails = styled.div<{ $pastel: string }>`
   display: flex;
   align-items: center;
-  padding: 0.5rem 1rem;
-  border-radius: 1rem;
+  padding: 8px 16px;
+  border-radius: 16px;
   background: ${({ $pastel }) => $pastel};
-  gap: 16px;
+  gap: 1rem;
   width: 100%;
   cursor: pointer;
   user-select: none;
   outline: none;
 
   &:focus {
-    box-shadow: 0 0 0 0.125rem #007aff55;
+    box-shadow: 0 0 0 2px #007aff55;
   }
 `
 
@@ -172,13 +172,13 @@ const GoalDetailText = styled.div`
 
 const GoalTitle = styled.span`
   color: #232326;
-  font-size: 15px;
+  font-size: 0.9375rem;
   font-weight: 500;
   text-align: left;
 `
 const GoalDesc = styled.span`
   color: #62636c;
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-weight: 400;
   text-align: left;
 `
@@ -194,10 +194,10 @@ const CheckboxLabel = styled.label<{ $main: string }>`
 
   span {
     display: inline-block;
-    width: 1.25rem;
-    height: 1.25rem;
+    width: 20px;
+    height: 20px;
     border: 2px solid ${({ $main }) => $main};
-    border-radius: 0.5rem;
+    border-radius: 8px;
     background: #fff;
     transition:
       background 0.15s,
@@ -228,7 +228,7 @@ const CheckboxLabel = styled.label<{ $main: string }>`
 const GoalProgress = styled.div<{ $completed: boolean }>`
   display: flex;
   align-items: center;
-  font-size: 14px;
+  font-size: 0.875rem;
   color: ${({ $completed }) => ($completed ? '#099f55' : 'black')};
   font-weight: 500;
   gap: 4px;

--- a/src/components/DailyGoal.tsx
+++ b/src/components/DailyGoal.tsx
@@ -40,14 +40,14 @@ const goalTheme = {
 
 const Card = styled.section`
   display: flex;
-  padding: 32px 24px;
+  padding: 2rem 1.5rem;
   flex-direction: column;
   align-items: flex-start;
   gap: 24px;
   align-self: stretch;
   background: #fff;
-  border-radius: 16px;
-  box-shadow: 0 2px 12px rgba(32, 32, 56, 0.06);
+  border-radius: 1rem;
+  box-shadow: 0 0.125rem 0.75rem rgba(32, 32, 56, 0.06);
 `
 
 const CardHeader = styled.header`
@@ -71,8 +71,8 @@ const CardHeader = styled.header`
   }
 
   svg {
-    width: 22px;
-    height: 22px;
+    width: 1.5rem;
+    height: 1.5rem;
     color: #c1c1c1;
     cursor: pointer;
 
@@ -88,30 +88,30 @@ const GoalList = styled.ul`
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
   align-self: stretch;
 `
 
 const GoalItem = styled.li`
   display: flex;
-  gap: 20px;
+  gap: 16px;
   align-items: flex-start;
 `
 
 const GoalIconBox = styled.div<{ $main: string }>`
-  width: 40px;
-  height: 40px;
-  min-width: 40px;
-  min-height: 40px;
+  width: 2.5rem;
+  height: 2.5rem;
+  min-width: 2.5rem;
+  min-height: 2.5rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 12px;
+  border-radius: 0.75rem;
   background: ${({ $main }) => $main};
 
   svg {
-    width: 24px;
-    height: 24px;
+    width: 1.5rem;
+    height: 1.5rem;
     display: block;
     fill: #fff;
     color: #fff;
@@ -127,14 +127,14 @@ const GoalInfo = styled.article`
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
   align-items: flex-start;
 `
 
 const GoalHeader = styled.div`
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   font-size: 15px;
   color: #232326;
   font-weight: 600;
@@ -149,17 +149,17 @@ const GoalObjectif = styled.span`
 const GoalDetails = styled.div<{ $pastel: string }>`
   display: flex;
   align-items: center;
-  padding: 10px 14px;
-  border-radius: 14px;
+  padding: 0.5rem 1rem;
+  border-radius: 1rem;
   background: ${({ $pastel }) => $pastel};
-  gap: 18px;
+  gap: 16px;
   width: 100%;
   cursor: pointer;
   user-select: none;
   outline: none;
 
   &:focus {
-    box-shadow: 0 0 0 2px #007aff55;
+    box-shadow: 0 0 0 0.125rem #007aff55;
   }
 `
 
@@ -194,10 +194,10 @@ const CheckboxLabel = styled.label<{ $main: string }>`
 
   span {
     display: inline-block;
-    width: 20px;
-    height: 20px;
+    width: 1.25rem;
+    height: 1.25rem;
     border: 2px solid ${({ $main }) => $main};
-    border-radius: 6px;
+    border-radius: 0.5rem;
     background: #fff;
     transition:
       background 0.15s,

--- a/src/components/DailyGoal.tsx
+++ b/src/components/DailyGoal.tsx
@@ -1,4 +1,4 @@
-import { useState, type KeyboardEvent } from 'react'
+import { useCallback, useMemo, useState, type KeyboardEvent } from 'react'
 import styled from 'styled-components'
 import { DotsHorizontalIcon, LapTimerIcon, TargetIcon } from '@radix-ui/react-icons'
 import YogaIcon from '@/assets/icons/yoga.svg?react'
@@ -237,21 +237,21 @@ const GoalProgress = styled.div<{ $completed: boolean }>`
 const DailyGoal = ({ goals }: DailyGoalProps) => {
   const [userGoals, setUserGoals] = useState(goals)
 
-  const handleToggle = (idx: number) => {
+  const handleToggle = useCallback((idx: number) => {
     setUserGoals((goals) => goals.map((g, i) => (i === idx ? { ...g, done: !g.done } : g)))
-  }
+  }, [])
 
-  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>, idx: number) => {
-    if (e.key === ' ' || e.key === 'Enter') {
-      e.preventDefault()
-      handleToggle(idx)
-    }
-  }
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>, idx: number) => {
+      if (e.key === ' ' || e.key === 'Enter') {
+        e.preventDefault()
+        handleToggle(idx)
+      }
+    },
+    [handleToggle]
+  )
 
-  const getCompletedGoalsCount = (goals: Goal[]) =>
-    goals.filter((goal) => goal.done).length
-
-  const completedGoals = getCompletedGoalsCount(userGoals)
+  const completedGoals = useMemo(() => userGoals.filter((goal) => goal.done).length, [userGoals])
   const totalGoals = userGoals.length
 
   return (
@@ -273,11 +273,11 @@ const DailyGoal = ({ goals }: DailyGoalProps) => {
           return (
             <GoalItem key={goal.title + idx}>
               <GoalIconBox $main={main}>
-                <MainIcon />
+                <MainIcon aria-hidden="true" />
               </GoalIconBox>
               <GoalInfo>
                 <GoalHeader>
-                  <ProgressIcon style={{ color: main }} />
+                  <ProgressIcon style={{ color: main }} aria-hidden="true" />
                   <GoalObjectif>
                     {goal.objectif.value}
                     {goal.objectif.unit}

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -18,11 +18,14 @@ const DashboardContainer = styled.section`
   flex: 1 0 0;
 `
 const DashboardCharts = styled.div`
-  display: flex;
-  align-items: flex-start;
+  display: grid;
   gap: 24px;
   flex: 1 0 0;
   align-self: stretch;
+  grid-template-columns: 3fr 1fr;
+  @media (max-width: 900px) {
+    grid-template-columns: 1fr;
+  }
 `
 
 const ChartsContainer = styled.div`

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -14,12 +14,12 @@ const DashboardContainer = styled.section`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 32px;
+  gap: 2rem;
   flex: 1 0 0;
 `
 const DashboardCharts = styled.div`
   display: grid;
-  gap: 24px;
+  gap: 1.5rem;
   flex: 1 0 0;
   align-self: stretch;
   grid-template-columns: 3fr 1fr;
@@ -32,12 +32,12 @@ const ChartsContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 24px;
+  gap: 1.5rem;
 `
 
 const ChartsGridContainer = styled.div`
   display: grid;
-  gap: 24px;
+  gap: 1.5rem;
   align-self: stretch;
   grid-template-rows: repeat(1, minmax(0, 1fr));
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -47,7 +47,7 @@ const DashboardAside = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 16px;
+  gap: 1rem;
   flex: 1 0 0;
   align-self: stretch;
 `

--- a/src/components/Dashboard/DashboardHeader.tsx
+++ b/src/components/Dashboard/DashboardHeader.tsx
@@ -31,12 +31,12 @@ const NotificationContainer = styled.div`
 
 const NotificationPopup = styled.div`
   display: flex;
-  min-width: 240px;
+  min-width: 15rem;
   gap: 8px;
-  padding: 16px 24px;
+  padding: 1rem 1.5rem;
   justify-content: space-between;
   align-items: center;
-  border-radius: 16px;
+  border-radius: 1rem;
   background: #d6fde4;
 
   span {
@@ -47,8 +47,8 @@ const NotificationPopup = styled.div`
   }
 
   svg {
-    width: 16px;
-    height: 16px;
+    width: 1rem;
+    height: 1rem;
     flex-shrink: 0;
     color: #0f462b;
   }
@@ -56,21 +56,21 @@ const NotificationPopup = styled.div`
 
 const NotificationButton = styled.button`
   display: flex;
-  width: 40px;
-  height: 40px;
+  width: 2.5rem;
+  height: 2.5rem;
 
   justify-content: center;
   align-items: center;
   flex-shrink: 0;
-  border-radius: 60px;
+  border-radius: 3.75rem;
   background: #f00;
   border: none;
   color: #ffffff;
   cursor: pointer;
 
   svg {
-    width: 15px;
-    height: 15px;
+    width: 1rem;
+    height: 1rem;
     flex-shrink: 0;
   }
 `

--- a/src/components/Dashboard/DashboardHeader.tsx
+++ b/src/components/Dashboard/DashboardHeader.tsx
@@ -90,12 +90,12 @@ const DashboardHeader = ({ name }: { name: string }) => {
       <NotificationContainer>
         {alertOpen && (
           <NotificationPopup>
-            <LightningBoltIcon />
+            <LightningBoltIcon aria-hidden="true" />
             <span>Félicitation ! Vous avez explosé vos objectifs hier 👏</span>
           </NotificationPopup>
         )}
         <NotificationButton onClick={handleOnClick} aria-label="Notification">
-          <BellIcon />
+          <BellIcon aria-hidden="true" />
         </NotificationButton>
       </NotificationContainer>
     </DashboardContainer>

--- a/src/components/Dashboard/DashboardHeader.tsx
+++ b/src/components/Dashboard/DashboardHeader.tsx
@@ -11,7 +11,7 @@ const DashboardContainer = styled.div`
   h1 {
     color: #1e1f24;
     text-align: left;
-    font-size: 32px;
+    font-size: 2rem;
     font-style: normal;
     font-weight: 500;
     line-height: normal;
@@ -26,29 +26,29 @@ const NotificationContainer = styled.div`
   display: flex;
   justify-content: flex-end;
   align-items: flex-start;
-  gap: 16px;
+  gap: 1rem;
 `
 
 const NotificationPopup = styled.div`
   display: flex;
-  min-width: 15rem;
-  gap: 8px;
-  padding: 1rem 1.5rem;
+  min-width: 240px;
+  gap: 0.5rem;
+  padding: 16px 24px;
   justify-content: space-between;
   align-items: center;
-  border-radius: 1rem;
+  border-radius: 16px;
   background: #d6fde4;
 
   span {
     color: #0f462b;
-    font-size: 16px;
+    font-size: 1rem;
     font-weight: 400;
     text-align: left;
   }
 
   svg {
-    width: 1rem;
-    height: 1rem;
+    width: 16px;
+    height: 16px;
     flex-shrink: 0;
     color: #0f462b;
   }
@@ -56,21 +56,21 @@ const NotificationPopup = styled.div`
 
 const NotificationButton = styled.button`
   display: flex;
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 40px;
+  height: 40px;
 
   justify-content: center;
   align-items: center;
   flex-shrink: 0;
-  border-radius: 3.75rem;
+  border-radius: 60px;
   background: #f00;
   border: none;
   color: #ffffff;
   cursor: pointer;
 
   svg {
-    width: 1rem;
-    height: 1rem;
+    width: 16px;
+    height: 16px;
     flex-shrink: 0;
   }
 `

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,10 +3,10 @@ import styled from 'styled-components'
 const FooterContainer = styled.footer`
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: 1.25rem;
   align-self: stretch;
-  padding: 24px 40px;
-  font-size: 14px;
+  padding: 1.5rem 2.5rem;
+  font-size: 0.875rem;
 `
 const Copyright = styled.p`
   color: #979797;
@@ -18,11 +18,11 @@ const Copyright = styled.p`
 const MandatoryLinks = styled.ul`
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 0.25rem;
 
   > svg {
-    width: 12px;
-    height: 12px;
+    width: 0.75rem;
+    height: 0.75rem;
     aspect-ratio: 1/1;
     color: #979797;
   }
@@ -32,7 +32,7 @@ const MandatoryLinks = styled.ul`
 
     font-style: normal;
     font-weight: 500;
-    line-height: 24px;
+    line-height: 1.5rem;
 
     &:hover {
       text-decoration: underline;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -49,15 +49,15 @@ const Footer = () => {
         <li>
           <a href="#">Mentions légales</a>
         </li>
-        <DotFilledIcon />
+        <DotFilledIcon aria-hidden="true" />
         <li>
           <a href="#">Confidentialité</a>
         </li>
-        <DotFilledIcon />
+        <DotFilledIcon aria-hidden="true" />
         <li>
           <a href="#">CGU</a>
         </li>
-        <DotFilledIcon />
+        <DotFilledIcon aria-hidden="true" />
         <li>
           <a href="#">Politique de cookies</a>
         </li>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,10 +3,10 @@ import styled from 'styled-components'
 const FooterContainer = styled.footer`
   display: flex;
   align-items: center;
-  gap: 1.25rem;
+  gap: 20px;
   align-self: stretch;
   padding: 1.5rem 2.5rem;
-  font-size: 0.875rem;
+  font-size: 14px;
 `
 const Copyright = styled.p`
   color: #979797;
@@ -18,7 +18,7 @@ const Copyright = styled.p`
 const MandatoryLinks = styled.ul`
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 4px;
 
   > svg {
     width: 0.75rem;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,10 +3,10 @@ import styled from 'styled-components'
 const FooterContainer = styled.footer`
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: 1.25rem;
   align-self: stretch;
-  padding: 1.5rem 2.5rem;
-  font-size: 14px;
+  padding: 24px 40px;
+  font-size: 0.875rem;
 `
 const Copyright = styled.p`
   color: #979797;
@@ -18,11 +18,11 @@ const Copyright = styled.p`
 const MandatoryLinks = styled.ul`
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 0.25rem;
 
   > svg {
-    width: 0.75rem;
-    height: 0.75rem;
+    width: 12px;
+    height: 12px;
     aspect-ratio: 1/1;
     color: #979797;
   }
@@ -32,7 +32,7 @@ const MandatoryLinks = styled.ul`
 
     font-style: normal;
     font-weight: 500;
-    line-height: 1.5rem;
+    line-height: 24px;
 
     &:hover {
       text-decoration: underline;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,14 +3,14 @@ import logoSVG from '/logo-name.svg'
 
 const HeaderContainer = styled.header`
   display: flex;
-  padding: 1.5rem 2.5rem;
+  padding: 24px 40px;
   align-items: center;
-  gap: 120px;
+  gap: 7.5rem;
 `
 const LogoWrapper = styled.button`
   background: none;
   border: none;
-  height: 1.5rem;
+  height: 24px;
   flex-shrink: 0;
 `
 
@@ -18,17 +18,17 @@ const NavWrapper = styled.nav`
   ul {
     display: flex;
     align-items: center;
-    gap: 24px;
+    gap: 1.5rem;
 
     a {
       font-weight: 700;
       text-transform: uppercase;
       display: flex;
-      padding: 0.5rem;
+      padding: 8px;
       flex-direction: column;
       justify-content: center;
       align-items: center;
-      gap: 8px;
+      gap: 0.5rem;
       color: #282d30;
 
       &:hover {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,14 +3,14 @@ import logoSVG from '/logo-name.svg'
 
 const HeaderContainer = styled.header`
   display: flex;
-  padding: 24px 40px;
+  padding: 1.5rem 2.5rem;
   align-items: center;
   gap: 120px;
 `
 const LogoWrapper = styled.button`
   background: none;
   border: none;
-  height: 24px;
+  height: 1.5rem;
   flex-shrink: 0;
 `
 
@@ -24,11 +24,11 @@ const NavWrapper = styled.nav`
       font-weight: 700;
       text-transform: uppercase;
       display: flex;
-      padding: 10px;
+      padding: 0.5rem;
       flex-direction: column;
       justify-content: center;
       align-items: center;
-      gap: 10px;
+      gap: 8px;
       color: #282d30;
 
       &:hover {

--- a/src/components/MacroCard.tsx
+++ b/src/components/MacroCard.tsx
@@ -8,16 +8,16 @@ import type { MacroData } from '@api/types.ts'
 const MacroCardContainer = styled.section`
   display: flex;
   flex-direction: column;
-  padding: 2rem 1.5rem;
-  gap: 16px;
+  padding: 32px 24px;
+  gap: 1rem;
   background: #fff;
-  border-radius: 1rem;
-  box-shadow: 0 0.125rem 0.75rem rgba(32, 32, 56, 0.06);
+  border-radius: 16px;
+  box-shadow: 0 2px 12px rgba(32, 32, 56, 0.06);
 `
 
 const CardTitle = styled.h3`
   color: #1e1f24;
-  font-size: 16px;
+  font-size: 1rem;
   font-weight: 500;
   margin: 0;
   text-align: left;
@@ -27,7 +27,7 @@ const MacroList = styled.ul`
   display: grid;
   grid-template-rows: repeat(2, minmax(0, 1fr));
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
+  gap: 0.5rem;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -44,26 +44,26 @@ const macroStyles = {
 const MacroItemContainer = styled.article<{ $bg: string }>`
   display: flex;
   align-items: center;
-  gap: 24px;
-  padding: 1rem;
+  gap: 1.5rem;
+  padding: 16px;
   background: ${({ $bg }) => $bg};
-  border-radius: 1rem;
+  border-radius: 16px;
   flex: 1 0 0;
   min-width: 0;
 `
 
 const MacroIconBox = styled.div`
   display: flex;
-  width: 3rem;
-  height: 3rem;
+  width: 48px;
+  height: 48px;
   justify-content: center;
   align-items: center;
   border-radius: 50%;
   background: #f9f9fb;
 
   svg {
-    width: 1.5rem;
-    height: 1.5rem;
+    width: 24px;
+    height: 24px;
     display: block;
   }
 `
@@ -76,15 +76,15 @@ const MacroInfo = styled.div`
 
   > span:first-child {
     color: #1e1f24;
-    font-size: 14px;
+    font-size: 0.875rem;
     font-weight: 700;
   }
 
   > span:nth-child(2) {
     color: #62636c;
-    font-size: 14px;
+    font-size: 0.875rem;
     font-weight: 500;
-    line-height: 1.5rem;
+    line-height: 24px;
   }
 `
 const MacroItem = ({ quantity, unit, macro }: MacroData) => {

--- a/src/components/MacroCard.tsx
+++ b/src/components/MacroCard.tsx
@@ -94,7 +94,7 @@ const MacroItem = ({ quantity, unit, macro }: MacroData) => {
   return (
     <MacroItemContainer $bg={bg}>
       <MacroIconBox>
-        <Icon />
+        <Icon aria-hidden="true" />
       </MacroIconBox>
       <MacroInfo>
         <span>

--- a/src/components/MacroCard.tsx
+++ b/src/components/MacroCard.tsx
@@ -8,11 +8,11 @@ import type { MacroData } from '@api/types.ts'
 const MacroCardContainer = styled.section`
   display: flex;
   flex-direction: column;
-  padding: 32px 24px;
+  padding: 2rem 1.5rem;
   gap: 16px;
   background: #fff;
-  border-radius: 16px;
-  box-shadow: 0 2px 12px rgba(32, 32, 56, 0.06);
+  border-radius: 1rem;
+  box-shadow: 0 0.125rem 0.75rem rgba(32, 32, 56, 0.06);
 `
 
 const CardTitle = styled.h3`
@@ -45,25 +45,25 @@ const MacroItemContainer = styled.article<{ $bg: string }>`
   display: flex;
   align-items: center;
   gap: 24px;
-  padding: 16px;
+  padding: 1rem;
   background: ${({ $bg }) => $bg};
-  border-radius: 16px;
+  border-radius: 1rem;
   flex: 1 0 0;
   min-width: 0;
 `
 
 const MacroIconBox = styled.div`
   display: flex;
-  width: 48px;
-  height: 48px;
+  width: 3rem;
+  height: 3rem;
   justify-content: center;
   align-items: center;
   border-radius: 50%;
   background: #f9f9fb;
 
   svg {
-    width: 24px;
-    height: 24px;
+    width: 1.5rem;
+    height: 1.5rem;
     display: block;
   }
 `
@@ -84,7 +84,7 @@ const MacroInfo = styled.div`
     color: #62636c;
     font-size: 14px;
     font-weight: 500;
-    line-height: 24px;
+    line-height: 1.5rem;
   }
 `
 const MacroItem = ({ quantity, unit, macro }: MacroData) => {

--- a/src/components/MacroCard.tsx
+++ b/src/components/MacroCard.tsx
@@ -33,9 +33,7 @@ const MacroList = styled.ul`
   padding: 0;
 `
 
-const MacroListItem = styled.li`
-  /* nothing extra needed here, all handled by MacroItemContainer */
-`
+const MacroListItem = styled.li``
 const macroStyles = {
   kCal: { Icon: EnergyIcon, bg: '#FF00001A' },
   Proteines: { Icon: ChickenIcon, bg: '#4AB8FF1A' },

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -138,7 +138,7 @@ const ProfileCard = ({ user, onEdit }: UserProfile) => {
           </h3>
           {onEdit && (
             <button aria-label="Edit profile" onClick={onEdit}>
-              <Pencil2Icon />
+              <Pencil2Icon aria-hidden="true" />
             </button>
           )}
         </Header>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -46,7 +46,7 @@ const InfoSection = styled.section`
   flex-direction: column;
   gap: 16px;
   flex: 1 1 0;
-  min-width: 0; /* key for text ellipsis! */
+  min-width: 0;
   justify-content: space-between;
 `
 

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -10,12 +10,12 @@ export interface UserProfile {
 const Card = styled.article`
   display: flex;
   flex-direction: row;
-  padding: 32px 24px;
+  padding: 2rem 1.5rem;
   align-items: flex-start;
   gap: 24px;
   background: #fff;
-  border-radius: 16px;
-  box-shadow: 0 2px 12px rgba(32, 32, 56, 0.06);
+  border-radius: 1rem;
+  box-shadow: 0 0.125rem 0.75rem rgba(32, 32, 56, 0.06);
   max-width: 100%;
   min-width: 0;
   overflow: hidden;
@@ -23,9 +23,9 @@ const Card = styled.article`
 
 const AvatarContainer = styled.figure`
   flex-shrink: 0;
-  width: 110px;
-  height: 110px;
-  border-radius: 16px;
+  width: 7rem;
+  height: 7rem;
+  border-radius: 1rem;
   overflow: hidden;
   margin: 0;
   background: #f3f3f6;
@@ -71,8 +71,8 @@ const Header = styled.header`
   button {
     border: none;
     background: none;
-    width: 22px;
-    height: 22px;
+    width: 1.5rem;
+    height: 1.5rem;
     padding: 0;
     cursor: pointer;
     display: flex;

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -10,12 +10,12 @@ export interface UserProfile {
 const Card = styled.article`
   display: flex;
   flex-direction: row;
-  padding: 2rem 1.5rem;
+  padding: 32px 24px;
   align-items: flex-start;
-  gap: 24px;
+  gap: 1.5rem;
   background: #fff;
-  border-radius: 1rem;
-  box-shadow: 0 0.125rem 0.75rem rgba(32, 32, 56, 0.06);
+  border-radius: 16px;
+  box-shadow: 0 2px 12px rgba(32, 32, 56, 0.06);
   max-width: 100%;
   min-width: 0;
   overflow: hidden;
@@ -23,9 +23,9 @@ const Card = styled.article`
 
 const AvatarContainer = styled.figure`
   flex-shrink: 0;
-  width: 7rem;
-  height: 7rem;
-  border-radius: 1rem;
+  width: 112px;
+  height: 112px;
+  border-radius: 16px;
   overflow: hidden;
   margin: 0;
   background: #f3f3f6;
@@ -44,7 +44,7 @@ const AvatarContainer = styled.figure`
 const InfoSection = styled.section`
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 1rem;
   flex: 1 1 0;
   min-width: 0;
   justify-content: space-between;
@@ -54,12 +54,12 @@ const Header = styled.header`
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 8px;
+  gap: 0.5rem;
   min-width: 0;
 
   h3 {
     color: #1e1f24;
-    font-size: 24px;
+    font-size: 1.5rem;
     font-weight: 500;
     margin: 0;
     min-width: 0;
@@ -71,8 +71,8 @@ const Header = styled.header`
   button {
     border: none;
     background: none;
-    width: 1.5rem;
-    height: 1.5rem;
+    width: 24px;
+    height: 24px;
     padding: 0;
     cursor: pointer;
     display: flex;
@@ -104,14 +104,14 @@ const Bio = styled.p`
 
 const DataGroup = styled.div`
   display: flex;
-  gap: 32px;
+  gap: 2rem;
   min-width: 0;
 
   > div {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 4px;
+    gap: 0.25rem;
 
     > span {
       color: #1e1f24;
@@ -122,7 +122,7 @@ const DataGroup = styled.div`
 
     > span:nth-child(2) {
       color: #979797;
-      font-size: 14px;
+      font-size: 0.875rem;
       font-weight: 400;
     }
   }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -102,27 +102,34 @@ interface SidebarProps {
   loading: boolean
 }
 
+const navIcons = [
+  { Icon: YogaIcon, label: 'Yoga' },
+  { Icon: SwimmingIcon, label: 'Natation' },
+  { Icon: CyclingIcon, label: 'Cyclisme' },
+  { Icon: WorkoutIcon, label: 'Musculation' },
+] as const
+
 const Sidebar = ({ picture, loading, firstName }: SidebarProps) => {
   return (
     <SidebarWrapper>
       <nav>
         <ul>
-          {[YogaIcon, SwimmingIcon, CyclingIcon, WorkoutIcon].map((Icon, i) => (
-            <li key={i}>
-              <HeaderIcon>
-                <Icon />
+          {navIcons.map(({ Icon, label }) => (
+            <li key={label}>
+              <HeaderIcon aria-label={label}>
+                <Icon aria-hidden="true" />
               </HeaderIcon>
             </li>
           ))}
         </ul>
       </nav>
       <SideBarFooter>
-        <GearIconWrapper>
-          <GearIcon />
+        <GearIconWrapper aria-label="Paramètres">
+          <GearIcon aria-hidden="true" />
         </GearIconWrapper>
         {!loading && picture && (
-          <ProfilPictureWrapper>
-            <img src={`/${picture}`} alt={`Profile Picture of ${firstName} `} />
+          <ProfilPictureWrapper aria-label="Profil">
+            <img src={`/${picture}`} alt={`Photo de profil de ${firstName}`} />
           </ProfilPictureWrapper>
         )}
       </SideBarFooter>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,8 +7,8 @@ import { GearIcon } from '@radix-ui/react-icons'
 
 const HeaderIcon = styled.button`
   display: flex;
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 40px;
+  height: 40px;
   flex-direction: column;
   justify-content: center;
   align-items: center;
@@ -16,12 +16,12 @@ const HeaderIcon = styled.button`
   border: none;
   background: none;
 
-  border-radius: 3.75rem;
+  border-radius: 60px;
   transition: 250ms ease-in-out;
 
   svg {
-    width: 1.5rem;
-    height: 1.5rem;
+    width: 24px;
+    height: 24px;
     flex-shrink: 0;
     aspect-ratio: 1/1;
 
@@ -38,10 +38,10 @@ const HeaderIcon = styled.button`
 
 const SidebarWrapper = styled.aside`
   height: 100%;
-  border-radius: 5rem;
+  border-radius: 80px;
   background: #fff;
   display: flex;
-  padding: 2rem 1rem;
+  padding: 32px 16px;
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
@@ -50,7 +50,7 @@ const SidebarWrapper = styled.aside`
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 40px;
+    gap: 2.5rem;
   }
 `
 const SideBarFooter = styled.div`
@@ -58,12 +58,12 @@ const SideBarFooter = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: 16px;
+  gap: 1rem;
 `
 
 const GearIconWrapper = styled.button`
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 24px;
+  height: 24px;
   border: none;
   background: none;
   cursor: pointer;
@@ -82,10 +82,10 @@ const GearIconWrapper = styled.button`
 `
 
 const ProfilPictureWrapper = styled.button`
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 40px;
+  height: 40px;
   aspect-ratio: 1/1;
-  border-radius: 2.5rem;
+  border-radius: 40px;
   overflow: hidden;
   border: none;
   cursor: pointer;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,8 +7,8 @@ import { GearIcon } from '@radix-ui/react-icons'
 
 const HeaderIcon = styled.button`
   display: flex;
-  width: 40px;
-  height: 40px;
+  width: 2.5rem;
+  height: 2.5rem;
   flex-direction: column;
   justify-content: center;
   align-items: center;
@@ -16,12 +16,12 @@ const HeaderIcon = styled.button`
   border: none;
   background: none;
 
-  border-radius: 60px;
+  border-radius: 3.75rem;
   transition: 250ms ease-in-out;
 
   svg {
-    width: 24px;
-    height: 24px;
+    width: 1.5rem;
+    height: 1.5rem;
     flex-shrink: 0;
     aspect-ratio: 1/1;
 
@@ -38,10 +38,10 @@ const HeaderIcon = styled.button`
 
 const SidebarWrapper = styled.aside`
   height: 100%;
-  border-radius: 85px;
+  border-radius: 5rem;
   background: #fff;
   display: flex;
-  padding: 32px 16px;
+  padding: 2rem 1rem;
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
@@ -62,8 +62,8 @@ const SideBarFooter = styled.div`
 `
 
 const GearIconWrapper = styled.button`
-  width: 24px;
-  height: 24px;
+  width: 1.5rem;
+  height: 1.5rem;
   border: none;
   background: none;
   cursor: pointer;
@@ -82,10 +82,10 @@ const GearIconWrapper = styled.button`
 `
 
 const ProfilPictureWrapper = styled.button`
-  width: 40px;
-  height: 40px;
+  width: 2.5rem;
+  height: 2.5rem;
   aspect-ratio: 1/1;
-  border-radius: 40px;
+  border-radius: 2.5rem;
   overflow: hidden;
   border: none;
   cursor: pointer;

--- a/src/components/charts/AverageSessionChart.tsx
+++ b/src/components/charts/AverageSessionChart.tsx
@@ -43,18 +43,18 @@ const CustomTooltip = ({
 
 const ChartWrapper = styled.div`
   background: red;
-  border-radius: 1rem;
-  padding: 1rem;
+  border-radius: 16px;
+  padding: 16px;
 `
 
 const ChartTitle = styled.h3`
   color: rgba(255, 255, 255, 0.85);
   text-align: left;
-  font-size: 15px;
-  margin: 0 1rem;
+  font-size: 0.9375rem;
+  margin: 0 16px;
   font-style: normal;
   font-weight: 500;
-  line-height: 1.5rem;
+  line-height: 24px;
   position: relative;
 `
 

--- a/src/components/charts/AverageSessionChart.tsx
+++ b/src/components/charts/AverageSessionChart.tsx
@@ -43,18 +43,18 @@ const CustomTooltip = ({
 
 const ChartWrapper = styled.div`
   background: red;
-  border-radius: 20px;
-  padding: 16px;
+  border-radius: 1rem;
+  padding: 1rem;
 `
 
 const ChartTitle = styled.h3`
   color: rgba(255, 255, 255, 0.85);
   text-align: left;
   font-size: 15px;
-  margin: 0 16px;
+  margin: 0 1rem;
   font-style: normal;
   font-weight: 500;
-  line-height: 24px;
+  line-height: 1.5rem;
   position: relative;
 `
 

--- a/src/components/charts/AverageSessionChart.tsx
+++ b/src/components/charts/AverageSessionChart.tsx
@@ -29,7 +29,7 @@ const CustomTooltip = ({
   payload,
 }: {
   active?: boolean
-  payload?: { value: number }[]
+  payload?: Array<{ value: number }>
 }) => {
   if (active && payload && payload.length > 0 && payload[0]?.value !== undefined) {
     return (
@@ -64,7 +64,7 @@ interface AverageSessionChartProps {
 
 const AverageSessionChart = ({ data }: AverageSessionChartProps) => {
   return (
-    <ChartWrapper>
+    <ChartWrapper role="img" aria-label="Durée moyenne des sessions">
       <ChartTitle>Durée moyenne des sessions</ChartTitle>
       <ResponsiveContainer width="100%" aspect={1}>
         <LineChart data={data} margin={{ right: 16, left: 16, top: 16 }}>

--- a/src/components/charts/DailyActivityChart.tsx
+++ b/src/components/charts/DailyActivityChart.tsx
@@ -11,7 +11,19 @@ import {
 } from 'recharts'
 import styled from 'styled-components'
 
-const CustomTooltip = ({ active, payload }: { active?: boolean; payload?: any[] }) => {
+const CustomTooltip = ({
+  active,
+  payload,
+}: {
+  active?: boolean
+  payload?: Array<{
+    dataKey: string
+    value: number
+    color?: string
+    fill?: string
+    payload: ActivitySession
+  }>
+}) => {
   if (active && payload && payload.length > 0) {
     const data = payload[0].payload
 
@@ -89,7 +101,7 @@ interface DailyActivityChartProps {
 
 const DailyActivityChart = ({ data }: DailyActivityChartProps) => {
   return (
-    <ChartWrapper>
+    <ChartWrapper role="img" aria-label="Activité quotidienne">
       <ChartTitle>Activité quotidienne</ChartTitle>
       <ResponsiveContainer width="100%" height="100%">
         <BarChart data={data} margin={{ right: 16, left: 16, top: 16, bottom: 32 }}>

--- a/src/components/charts/DailyActivityChart.tsx
+++ b/src/components/charts/DailyActivityChart.tsx
@@ -76,7 +76,7 @@ const CustomTooltip = ({
 
 const ChartWrapper = styled.div`
   background: #fff;
-  border-radius: 1.25rem;
+  border-radius: 1.5rem;
   padding: 1rem;
   align-self: stretch;
   height: 20rem;
@@ -87,7 +87,7 @@ const ChartWrapper = styled.div`
 const ChartTitle = styled.h3`
   color: rgba(0, 0, 0, 0.85);
   text-align: left;
-  font-size: 0.9375rem;
+  font-size: 15px;
   margin: 0 1rem;
   font-style: normal;
   font-weight: 500;

--- a/src/components/charts/DailyActivityChart.tsx
+++ b/src/components/charts/DailyActivityChart.tsx
@@ -76,10 +76,10 @@ const CustomTooltip = ({
 
 const ChartWrapper = styled.div`
   background: #fff;
-  border-radius: 1.5rem;
-  padding: 1rem;
+  border-radius: 24px;
+  padding: 16px;
   align-self: stretch;
-  height: 20rem;
+  height: 320px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -87,11 +87,11 @@ const ChartWrapper = styled.div`
 const ChartTitle = styled.h3`
   color: rgba(0, 0, 0, 0.85);
   text-align: left;
-  font-size: 15px;
-  margin: 0 1rem;
+  font-size: 0.9375rem;
+  margin: 0 16px;
   font-style: normal;
   font-weight: 500;
-  line-height: 1.5rem;
+  line-height: 24px;
   position: relative;
 `
 interface DailyActivityChartProps {

--- a/src/components/charts/DailyActivityChart.tsx
+++ b/src/components/charts/DailyActivityChart.tsx
@@ -27,7 +27,6 @@ const CustomTooltip = ({
   if (active && payload && payload.length > 0) {
     const data = payload[0].payload
 
-    // French date "7 juil.24"
     let dateLabel = data.day
     if (typeof data.day === 'string') {
       const date = new Date(data.day)
@@ -77,22 +76,22 @@ const CustomTooltip = ({
 
 const ChartWrapper = styled.div`
   background: #fff;
-  border-radius: 20px;
-  padding: 16px;
+  border-radius: 1.25rem;
+  padding: 1rem;
   align-self: stretch;
-  height: 320px;
-  box-sizing: border-box; /* Important for padding math */
+  height: 20rem;
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
 `
 const ChartTitle = styled.h3`
   color: rgba(0, 0, 0, 0.85);
   text-align: left;
-  font-size: 15px;
-  margin: 0 16px;
+  font-size: 0.9375rem;
+  margin: 0 1rem;
   font-style: normal;
   font-weight: 500;
-  line-height: 24px;
+  line-height: 1.5rem;
   position: relative;
 `
 interface DailyActivityChartProps {

--- a/src/components/charts/GoalChart.tsx
+++ b/src/components/charts/GoalChart.tsx
@@ -7,19 +7,19 @@ interface GoalChartProps {
 
 const ChartWrapper = styled.div`
   background: #fff;
-  border-radius: 1rem;
-  padding: 1rem;
+  border-radius: 16px;
+  padding: 16px;
   position: relative;
 `
 
 const ChartTitle = styled.h3`
   color: rgb(32, 37, 58);
   text-align: left;
-  font-size: 15px;
-  margin: 0 1rem;
+  font-size: 0.9375rem;
+  margin: 0 16px;
   font-style: normal;
   font-weight: 500;
-  line-height: 1.5rem;
+  line-height: 24px;
   position: relative;
 `
 
@@ -27,21 +27,21 @@ const CenterLabel = styled.div`
   position: absolute;
   left: 50%;
   top: 50%;
-  transform: translate(-50%, calc(-50% + 0.5rem));
+  transform: translate(-50%, calc(-50% + 8px));
   display: flex;
   flex-direction: column;
   align-items: center;
 
   font-weight: bold;
-  font-size: 32px;
+  font-size: 2rem;
   color: #282d30;
 
   font-style: normal;
   span {
-    font-size: 14px;
+    font-size: 0.875rem;
     font-weight: 500;
     color: #74798c;
-    margin-top: 0.25rem;
+    margin-top: 4px;
   }
 `
 

--- a/src/components/charts/GoalChart.tsx
+++ b/src/components/charts/GoalChart.tsx
@@ -7,8 +7,8 @@ interface GoalChartProps {
 
 const ChartWrapper = styled.div`
   background: #fff;
-  border-radius: 20px;
-  padding: 16px;
+  border-radius: 1rem;
+  padding: 1rem;
   position: relative;
 `
 
@@ -16,10 +16,10 @@ const ChartTitle = styled.h3`
   color: rgb(32, 37, 58);
   text-align: left;
   font-size: 15px;
-  margin: 0 16px;
+  margin: 0 1rem;
   font-style: normal;
   font-weight: 500;
-  line-height: 24px;
+  line-height: 1.5rem;
   position: relative;
 `
 
@@ -27,7 +27,7 @@ const CenterLabel = styled.div`
   position: absolute;
   left: 50%;
   top: 50%;
-  transform: translate(-50%, calc(-50% + 8px));
+  transform: translate(-50%, calc(-50% + 0.5rem));
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -41,7 +41,7 @@ const CenterLabel = styled.div`
     font-size: 14px;
     font-weight: 500;
     color: #74798c;
-    margin-top: 2px;
+    margin-top: 0.25rem;
   }
 `
 

--- a/src/components/charts/GoalChart.tsx
+++ b/src/components/charts/GoalChart.tsx
@@ -57,7 +57,7 @@ const GoalChart = ({ data }: GoalChartProps) => {
   ]
 
   return (
-    <ChartWrapper>
+    <ChartWrapper role="img" aria-label="Score de l'objectif">
       <ChartTitle>Score</ChartTitle>
       <ResponsiveContainer width="100%" aspect={1} height="100%">
         <RadialBarChart

--- a/src/components/charts/PerformanceChart.tsx
+++ b/src/components/charts/PerformanceChart.tsx
@@ -11,8 +11,8 @@ import {
 
 const ChartWrapper = styled.div`
   background: #282d30;
-  border-radius: 1rem;
-  padding: 1rem;
+  border-radius: 16px;
+  padding: 16px;
   position: relative;
 `
 

--- a/src/components/charts/PerformanceChart.tsx
+++ b/src/components/charts/PerformanceChart.tsx
@@ -11,8 +11,8 @@ import {
 
 const ChartWrapper = styled.div`
   background: #282d30;
-  border-radius: 20px;
-  padding: 16px;
+  border-radius: 1rem;
+  padding: 1rem;
   position: relative;
 `
 

--- a/src/components/charts/PerformanceChart.tsx
+++ b/src/components/charts/PerformanceChart.tsx
@@ -16,7 +16,6 @@ const ChartWrapper = styled.div`
   position: relative;
 `
 
-// Type for the recharts tooltip payload
 interface TooltipPayload {
   value: number
   payload: PerformanceEntry & { kindLabel?: string }

--- a/src/components/charts/PerformanceChart.tsx
+++ b/src/components/charts/PerformanceChart.tsx
@@ -58,7 +58,7 @@ const PerformanceChart = ({ data }: PerformanceChartProps) => {
   }))
 
   return (
-    <ChartWrapper>
+    <ChartWrapper role="img" aria-label="Performance">
       <ResponsiveContainer width="100%" height="100%">
         <RadarChart
           data={chartData}

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap');
 
-/* Reset CSS */
 *,
 *::before,
 *::after {
@@ -12,6 +11,10 @@
 html,
 body {
   height: 100%;
+}
+
+html {
+  font-size: clamp(14px, 1.5vw, 16px);
 }
 
 body {

--- a/src/index.css
+++ b/src/index.css
@@ -4,34 +4,35 @@
 *,
 *::before,
 *::after {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
-html, body {
-    height: 100%;
+html,
+body {
+  height: 100%;
 }
 
 body {
-    min-height: 100vh;
-    font-family: "Inter", system-ui, Avenir, Helvetica, Arial, sans-serif;
-    background: #F0F0F0;
-    color: #222;
-    font-synthesis: none;
-    text-rendering: optimizeLegibility;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+  min-height: 100vh;
+  font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;
+  background: #f0f0f0;
+  color: #222;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 ul,
 ol {
-    list-style: none;
-    padding: 0;
+  list-style: none;
+  padding: 0;
 }
 
 a {
-    color: inherit;
-    text-decoration: none;
-    cursor: pointer;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- refactor sidebar icons with labels and accessible buttons
- add useCallback/useMemo in DailyGoal
- update dashboard layout to CSS grid
- add ARIA labels to charts
- mark decorative icons as aria-hidden
- add return type to API handler

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685efc991bc08332bb5c3faa1034e658