### PR TITLE
Improve dashboard layout responsiveness

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,10 +1,24 @@
 #root {
-  display: flex;
-  width: 100%;
-  height: 100%;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: flex-start;
-  margin: 0 auto;
-  text-align: center;
+    display: flex;
+    width: 100%;
+    height: 100%;
+    max-width: 100dvw;
+    max-height: 100dvh;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-start;
+    margin: 0 auto;
+    text-align: center;
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+header, footer {
+    flex: 0 0 auto
+}
+
+main {
+    flex: 1 1 auto; /* Grow to fill the rest */
+    overflow: hidden; /* If content too big, scroll INSIDE main, not out */
+    min-height: 0; /* Critical! Prevents weird overflow */
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,17 +10,25 @@ import { fetchUserData } from '@/hooks/user.tsx'
 import type { UserData } from '../api/types'
 
 const Layout = styled.main`
-  width: 100%;
-  height: 100%;
-  display: grid;
-  grid-template-columns: auto 1fr;
-  padding: 32px 40px;
-  gap: 2.5rem;
+  display: flex;
+  padding: 0 40px;
+  width: 100vw;
+  box-sizing: border-box;
+  justify-content: flex-start;
 
   @media (max-width: 768px) {
-    grid-template-columns: 1fr;
+    flex-direction: column;
     padding: 16px;
   }
+`
+const DashboardOuter = styled.div`
+  flex: 1 1 auto;
+  display: flex;
+  justify-content: flex-start;
+  width: 100%;
+  min-width: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
 `
 
 const App = () => {
@@ -40,7 +48,13 @@ const App = () => {
       <Header />
       <Layout>
         <Sidebar picture={userData?.picture} firstName={userData?.firstName} loading={isPending} />
-        {isPending ? <div>Chargement ...</div> : <Dashboard user={userData} />}
+        {isPending ? (
+          <div>Chargement ...</div>
+        ) : (
+          <DashboardOuter>
+            <Dashboard user={userData} />
+          </DashboardOuter>
+        )}
       </Layout>
       <Footer />
     </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,10 +12,15 @@ import type { UserData } from '../api/types'
 const Layout = styled.main`
   width: 100%;
   height: 100%;
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr;
   padding: 32px 40px;
-  align-items: flex-start;
   gap: 2.5rem;
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+    padding: 16px;
+  }
 `
 
 const App = () => {

--- a/src/components/DailyGoal.tsx
+++ b/src/components/DailyGoal.tsx
@@ -194,10 +194,10 @@ const CheckboxLabel = styled.label<{ $main: string }>`
 
   span {
     display: inline-block;
-    width: 20px;
-    height: 20px;
+    width: 16px;
+    height: 16px;
     border: 2px solid ${({ $main }) => $main};
-    border-radius: 8px;
+    border-radius: 4px;
     background: #fff;
     transition:
       background 0.15s,

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -64,7 +64,7 @@ const Dashboard = ({ user }: DashboardProps) => {
         <Item $span={2}>
           <ProfileCard user={user} />
         </Item>
-        <Item>
+        <Item $span={1}>
           <MacroCard macros={user.keyData} />
         </Item>
         <Item>

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -12,20 +12,35 @@ import PerformanceChart from '@/components/charts/PerformanceChart.tsx'
 import MealPrepCard from '@/components/MealPrepCard.tsx'
 
 const DashboardContainer = styled.section`
+  max-width: 1440px;
+  width: 100%;
+  margin-right: auto;
+  padding: 0 2.5rem;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   gap: 2rem;
-  flex: 1 0 0;
+
+  @media (max-width: 1440px) {
+    max-width: 100vw;
+    margin-left: 16px;
+    padding: 0 1rem;
+  }
+  @media (max-width: 768px) {
+    margin-left: 0;
+    padding: 0;
+  }
 `
+
 const DashboardCharts = styled.div`
   display: grid;
   gap: 1.5rem;
-  flex: 1 0 0;
-  align-self: stretch;
   grid-template-columns: 3fr 1fr;
+  align-items: stretch; /* << KEY!! both columns get full height of the tallest child */
+  min-height: 0;
   @media (max-width: 900px) {
     grid-template-columns: 1fr;
+    align-items: start;
   }
 `
 
@@ -49,7 +64,7 @@ const DashboardAside = styled.div`
   flex-direction: column;
   align-items: flex-start;
   gap: 1rem;
-  flex: 1 0 0;
+
   align-self: stretch;
 `
 

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -1,5 +1,5 @@
 import DashboardHeader from '@/components/Dashboard/DashboardHeader.tsx'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import ProfileCard from '@/components/ProfileCard.tsx'
 import MacroCard from '@/components/MacroCard.tsx'
@@ -14,43 +14,28 @@ import MealPrepCard from '@/components/MealPrepCard.tsx'
 const DashboardContainer = styled.section`
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
   gap: 2rem;
-  flex: 1 0 0;
+  flex: 1;
+  width: 100%;
 `
-const DashboardCharts = styled.div`
+
+const DashboardGrid = styled.div`
   display: grid;
+  width: 100%;
   gap: 1.5rem;
-  flex: 1 0 0;
-  align-self: stretch;
-  grid-template-columns: 3fr 1fr;
-  @media (max-width: 900px) {
-    grid-template-columns: 1fr;
-  }
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: stretch;
 `
 
-const ChartsContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 1.5rem;
-`
-
-const ChartsGridContainer = styled.div`
-  display: grid;
-  gap: 1.5rem;
-  align-self: stretch;
-  grid-template-rows: repeat(1, minmax(0, 1fr));
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-`
-
-const DashboardAside = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 1rem;
-  flex: 1 0 0;
-  align-self: stretch;
+const Item = styled.div<{ $span?: number }>`
+  width: 100%;
+  ${(p) =>
+    p.$span &&
+    css`
+      @media (min-width: 1024px) {
+        grid-column: span ${p.$span};
+      }
+    `}
 `
 
 interface DashboardProps {
@@ -60,22 +45,32 @@ const Dashboard = ({ user }: DashboardProps) => {
   return (
     <DashboardContainer>
       <DashboardHeader name={user.firstName} />
-      <DashboardCharts>
-        <ChartsContainer>
+      <DashboardGrid>
+        <Item $span={2}>
           <DailyActivityChart data={user.activity} />
-          <ChartsGridContainer>
-            <PerformanceChart data={user.performance} />
-            <GoalChart data={user.score || user.todayScore || null} />
-            <AverageSessionChart data={user.averageSessions} />
-          </ChartsGridContainer>
+        </Item>
+        <Item>
+          <PerformanceChart data={user.performance} />
+        </Item>
+        <Item>
+          <GoalChart data={user.score || user.todayScore || null} />
+        </Item>
+        <Item>
+          <AverageSessionChart data={user.averageSessions} />
+        </Item>
+        <Item $span={2}>
           <MealPrepCard />
-        </ChartsContainer>
-        <DashboardAside>
+        </Item>
+        <Item $span={2}>
           <ProfileCard user={user} />
+        </Item>
+        <Item>
           <MacroCard macros={user.keyData} />
+        </Item>
+        <Item>
           <DailyGoal goals={user.goals} />
-        </DashboardAside>
-      </DashboardCharts>
+        </Item>
+      </DashboardGrid>
     </DashboardContainer>
   )
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -7,6 +7,8 @@ const FooterContainer = styled.footer`
   align-self: stretch;
   padding: 24px 40px;
   font-size: 0.875rem;
+  border-top: 1px solid #e5e5e5;
+  margin-top: 24px;
 `
 const Copyright = styled.p`
   color: #979797;

--- a/src/components/MealPrepCard.tsx
+++ b/src/components/MealPrepCard.tsx
@@ -9,6 +9,7 @@ const Card = styled.section`
   background: #fff;
   border-radius: 16px;
   box-shadow: 0 2px 12px rgba(32, 32, 56, 0.06);
+  align-self: stretch;
 `
 
 const CardTitle = styled.h3`
@@ -24,6 +25,15 @@ const CardTitle = styled.h3`
     font-weight: 500;
     margin-left: 0.5rem;
   }
+`
+
+const CardGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 `
 
 const MealItem = styled.div`
@@ -69,35 +79,37 @@ const Info = styled.div`
 const MealPrepCard = () => (
   <Card>
     <CardTitle>
-      Préparation des repas <span>(configurée repas végé)</span>
+      Préparation des repas <span>végétarien</span>
     </CardTitle>
-    <MealItem>
-      <IconBox>
-        <AppleIcon aria-hidden="true" />
-      </IconBox>
-      <Info>
-        <span>Salade quinoa</span>
-        <span>350kCal • 15g prot • 10min</span>
-      </Info>
-    </MealItem>
-    <MealItem>
-      <IconBox>
-        <AppleIcon aria-hidden="true" />
-      </IconBox>
-      <Info>
-        <span>Pâtes aux légumes</span>
-        <span>600kCal • 25g prot • 25min</span>
-      </Info>
-    </MealItem>
-    <MealItem>
-      <IconBox>
-        <AppleIcon aria-hidden="true" />
-      </IconBox>
-      <Info>
-        <span>Smoothie protéiné</span>
-        <span>250kCal • 20g prot • 5min</span>
-      </Info>
-    </MealItem>
+    <CardGrid>
+      <MealItem>
+        <IconBox>
+          <AppleIcon aria-hidden="true" />
+        </IconBox>
+        <Info>
+          <span>Salade quinoa</span>
+          <span>350kCal • 15g prot • 10min</span>
+        </Info>
+      </MealItem>
+      <MealItem>
+        <IconBox>
+          <AppleIcon aria-hidden="true" />
+        </IconBox>
+        <Info>
+          <span>Pâtes aux légumes</span>
+          <span>600kCal • 25g prot • 25min</span>
+        </Info>
+      </MealItem>
+      <MealItem>
+        <IconBox>
+          <AppleIcon aria-hidden="true" />
+        </IconBox>
+        <Info>
+          <span>Smoothie protéiné</span>
+          <span>250kCal • 20g prot • 5min</span>
+        </Info>
+      </MealItem>
+    </CardGrid>
   </Card>
 )
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -37,6 +37,8 @@ const HeaderIcon = styled.button`
 `
 
 const SidebarWrapper = styled.aside`
+  min-width: 60px;
+  max-width: 80px;
   height: 100%;
   width: 80px;
   border-radius: 80px;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -38,6 +38,7 @@ const HeaderIcon = styled.button`
 
 const SidebarWrapper = styled.aside`
   height: 100%;
+  width: 80px;
   border-radius: 80px;
   background: #fff;
   display: flex;
@@ -45,6 +46,13 @@ const SidebarWrapper = styled.aside`
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
+
+  @media (max-width: 768px) {
+    flex-direction: row;
+    width: auto;
+    height: auto;
+    border-radius: 16px;
+  }
 
   ul {
     display: flex;

--- a/src/components/charts/AverageSessionChart.tsx
+++ b/src/components/charts/AverageSessionChart.tsx
@@ -45,6 +45,8 @@ const ChartWrapper = styled.div`
   background: red;
   border-radius: 16px;
   padding: 16px;
+  height: 100%;
+  width: 100%;
 `
 
 const ChartTitle = styled.h3`

--- a/src/components/charts/DailyActivityChart.tsx
+++ b/src/components/charts/DailyActivityChart.tsx
@@ -79,7 +79,8 @@ const ChartWrapper = styled.div`
   border-radius: 24px;
   padding: 1rem;
   align-self: stretch;
-  height: 320px;
+  height: 100%;
+  width: 100%;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;

--- a/src/components/charts/DailyActivityChart.tsx
+++ b/src/components/charts/DailyActivityChart.tsx
@@ -79,7 +79,6 @@ const ChartWrapper = styled.div`
   border-radius: 24px;
   padding: 1rem;
   align-self: stretch;
-  height: 100%;
   width: 100%;
   box-sizing: border-box;
   display: flex;
@@ -103,7 +102,7 @@ const DailyActivityChart = ({ data }: DailyActivityChartProps) => {
   return (
     <ChartWrapper role="img" aria-label="Activité quotidienne">
       <ChartTitle>Activité quotidienne</ChartTitle>
-      <ResponsiveContainer width="100%" height="100%">
+      <ResponsiveContainer width="100%" height={260}>
         <BarChart data={data} margin={{ right: 16, left: 16, top: 16, bottom: 32 }}>
           <CartesianGrid vertical={false} />
           <XAxis

--- a/src/components/charts/DailyActivityChart.tsx
+++ b/src/components/charts/DailyActivityChart.tsx
@@ -117,7 +117,7 @@ const DailyActivityChart = ({ data }: DailyActivityChartProps) => {
             content={<CustomTooltip />}
             cursor={{ fill: '#fde2e4', opacity: 1 }}
           />
-          <Legend align="right" verticalAlign="top" wrapperStyle={{ top: -24 }} />
+          <Legend align="right" verticalAlign="top" wrapperStyle={{ top: -16 }} />
           <Bar
             dataKey="kilogram"
             name="Poids (kg)"

--- a/src/components/charts/GoalChart.tsx
+++ b/src/components/charts/GoalChart.tsx
@@ -10,6 +10,8 @@ const ChartWrapper = styled.div`
   border-radius: 16px;
   padding: 16px;
   position: relative;
+  height: 100%;
+  width: 100%;
 `
 
 const ChartTitle = styled.h3`

--- a/src/components/charts/PerformanceChart.tsx
+++ b/src/components/charts/PerformanceChart.tsx
@@ -14,6 +14,8 @@ const ChartWrapper = styled.div`
   border-radius: 16px;
   padding: 16px;
   position: relative;
+  height: 100%;
+  width: 100%;
 `
 
 interface TooltipPayload {
@@ -58,7 +60,7 @@ const PerformanceChart = ({ data }: PerformanceChartProps) => {
 
   return (
     <ChartWrapper role="img" aria-label="Performance">
-      <ResponsiveContainer width="100%" height="100%">
+      <ResponsiveContainer width="100%">
         <RadarChart
           data={chartData}
           outerRadius="75%"

--- a/src/index.css
+++ b/src/index.css
@@ -3,39 +3,43 @@
 *,
 *::before,
 *::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
 }
 
-html,
-body {
-  height: 100%;
+html, body {
+    height: 100%;
+    margin: 0;
+    padding: 0;
 }
 
 html {
-  font-size: clamp(14px, 1.5vw, 16px);
+    font-size: clamp(14px, 1.5vw, 16px);
 }
 
 body {
-  min-height: 100vh;
-  font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;
-  background: #f0f0f0;
-  color: #222;
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+    min-height: 100dvh; /* Or 100vh for most cases */
+    height: 100dvh;
+    display: flex;
+    flex-direction: column;
+    font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;
+    background: #f0f0f0;
+    color: #222;
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 ul,
 ol {
-  list-style: none;
-  padding: 0;
+    list-style: none;
+    padding: 0;
 }
 
 a {
-  color: inherit;
-  text-decoration: none;
-  cursor: pointer;
+    color: inherit;
+    text-decoration: none;
+    cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- refactor main layout to use responsive grid
- rework dashboard into a bento-style grid
- make sidebar width responsive

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
