### PR TITLE
Improve responsive breakpoints

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,10 @@ const Layout = styled.main`
   box-sizing: border-box;
   justify-content: flex-start;
 
+  @media (max-width: 1240px) {
+    padding: 0 24px;
+  }
+
   @media (max-width: 600px) {
     flex-direction: column;
     padding: unset;

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -21,6 +21,10 @@ const DashboardContainer = styled.section`
   align-items: flex-start;
   gap: 2rem;
 
+  @media (max-width: 1240px) {
+    padding: 0 32px;
+  }
+
   @media (max-width: 600px) {
     padding: 40px 24px;
   }
@@ -32,6 +36,9 @@ const DashboardCharts = styled.div`
   grid-template-columns: 3fr 1fr;
   align-items: stretch; /* << KEY!! both columns get full height of the tallest child */
   min-height: 0;
+  @media (max-width: 1240px) {
+    grid-template-columns: 2fr 1fr;
+  }
   @media (max-width: 900px) {
     grid-template-columns: 1fr;
     align-items: start;
@@ -56,6 +63,10 @@ const ChartsGridContainer = styled.div`
   align-self: stretch;
   grid-template-rows: repeat(1, minmax(0, 1fr));
   grid-template-columns: repeat(3, minmax(0, 1fr));
+
+  @media (max-width: 1240px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 
   @media (max-width: 600px) {
     grid-template-columns: 1fr;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,6 +14,11 @@ const HeaderContainer = styled.header`
   background: #fff;
   width: 100%;
 
+  @media (max-width: 1240px) {
+    gap: 4rem;
+    padding: 24px 32px;
+  }
+
   @media (max-width: 600px) {
     width: 100%;
     padding: 32px 24px;
@@ -92,7 +97,7 @@ const BurgerNavBackdrop = styled.div`
 `
 
 const Header = () => {
-  const isMobile = useMediaQuery('(max-width: 600px')
+  const isMobile = useMediaQuery('(max-width: 600px)')
   const [open, setOpen] = useState(false)
 
   return (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -60,6 +60,11 @@ const SidebarWrapper = styled.aside`
     width: 100%;
   }
 
+  @media (max-width: 1240px) {
+    width: 60px;
+    padding: 32px 8px;
+  }
+
   @media (max-width: 600px) {
     flex-direction: row;
     min-width: unset;

--- a/src/components/charts/AverageSessionChart.tsx
+++ b/src/components/charts/AverageSessionChart.tsx
@@ -43,11 +43,9 @@ const CustomTooltip = ({
 }
 
 const ChartWrapper = styled.div`
-  background: red;
+  background: #ff0000;
   border-radius: 16px;
   padding: 16px;
-  @media (max-width: 600px) {
-  }
 `
 
 const ChartTitle = styled.h3`
@@ -66,7 +64,7 @@ interface AverageSessionChartProps {
 }
 
 const AverageSessionChart = ({ data }: AverageSessionChartProps) => {
-  const isMobile = useMediaQuery('(max-width: 600px')
+  const isMobile = useMediaQuery('(max-width: 600px)')
   const aspectRatio = isMobile ? 2 : 1
 
   return (

--- a/src/components/charts/DailyActivityChart.tsx
+++ b/src/components/charts/DailyActivityChart.tsx
@@ -102,7 +102,7 @@ interface DailyActivityChartProps {
 }
 
 const DailyActivityChart = ({ data }: DailyActivityChartProps) => {
-  const isMobile = useMediaQuery('(max-width: 600px')
+  const isMobile = useMediaQuery('(max-width: 600px)')
   const aspectRatio = 2
   const LegendAlign = isMobile ? 'left' : 'right'
 

--- a/src/components/charts/GoalChart.tsx
+++ b/src/components/charts/GoalChart.tsx
@@ -47,7 +47,7 @@ const CenterLabel = styled.div`
 `
 
 const GoalChart = ({ data }: GoalChartProps) => {
-  const isMobile = useMediaQuery('(max-width: 600px')
+  const isMobile = useMediaQuery('(max-width: 600px)')
   const aspectRatio = isMobile ? 2 : 1
 
   const clamped = Math.max(0, Math.min(data!, 1))

--- a/src/components/charts/PerformanceChart.tsx
+++ b/src/components/charts/PerformanceChart.tsx
@@ -54,7 +54,7 @@ interface PerformanceChartProps {
 }
 
 const PerformanceChart = ({ data }: PerformanceChartProps) => {
-  const isMobile = useMediaQuery('(max-width: 600px')
+  const isMobile = useMediaQuery('(max-width: 600px)')
   const aspectRatio = isMobile ? 2 : 1
 
   const chartData: (PerformanceEntry & { kindLabel: string })[] = data.data.map((d) => ({


### PR DESCRIPTION
## Summary
- fix invalid media query syntax on mobile checks
- adjust dashboard paddings and grid for tablets
- tweak header and sidebar spacing for intermediate widths
- update average sessions chart background